### PR TITLE
pin out newer versions of fog stuff, causing errors on build servers

### DIFF
--- a/lib/vagrant-libvirt/version.rb
+++ b/lib/vagrant-libvirt/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module ProviderLibvirt
-    VERSION = '1.0.3'
+    VERSION = '1.0.4'
   end
 end

--- a/vagrant-libvirt.gemspec
+++ b/vagrant-libvirt.gemspec
@@ -20,7 +20,8 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rspec-expectations", "~> 2.12.1"
   gem.add_development_dependency "rspec-mocks", "~> 2.12.1"
 
-  gem.add_runtime_dependency 'fog-libvirt', '~> 0.0.1'
+  gem.add_runtime_dependency 'fog-libvirt', '< 0.0.4'
+  gem.add_runtime_dependency 'fog-core', '< 1.36.0'
   gem.add_runtime_dependency 'nokogiri', '~> 1.6.0'
 
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
So, things on the build servers are a little fucked
1.0.3 is actually the vagrant-libvirt that's been installed since december, so we're leaving that there
but these gems got installed today as well:


```
jenkins@build0004b1dfw2: ~/.vagrant.d/gems/gems $ ls -ailh | grep Mar
   2993318 drwxr-xr-x 58 jenkins root 4.0K Mar 18 02:59 .
1612626868 drwxr-xr-x  6 jenkins root 4.0K Mar 18 00:43 excon-0.48.0
1612626896 drwxr-xr-x  4 jenkins root 4.0K Mar 18 00:43 fog-core-1.36.0
 537297976 drwxr-xr-x  5 jenkins root  154 Mar 18 00:43 fog-libvirt-0.0.4
1076301461 drwxr-xr-x  5 jenkins root 4.0K Mar 18 00:43 net-ssh-2.9.4
 537298057 drwxr-xr-x  5 jenkins root   83 Mar 18 00:43 rubyzip-1.2.0
1613361808 drwxr-xr-x  7 jenkins root 4.0K Mar 18 02:42 vagrant-libvirt-1.0.2
1076377904 drwxr-xr-x  5 jenkins root 4.0K Mar 18 00:43 winrm-1.3.6
```


that's causing this issue with kitchen/vagrant builds

```
 ==> default: Creating shared folders metadata...
       ==> default: Starting domain.
       ==> default: Waiting for domain to get an IP address...
       ==> default: Removing domain...
       /home/jenkins/.vagrant.d/gems/gems/fog-core-1.36.0/lib/fog/core/service.rb:244:in `validate_options': Missing required arguments: libvirt_uri (ArgumentError)
        from /home/jenkins/.vagrant.d/gems/gems/fog-core-1.36.0/lib/fog/core/service.rb:268:in `handle_settings'
        from /home/jenkins/.vagrant.d/gems/gems/fog-core-1.36.0/lib/fog/core/service.rb:98:in `new'
        from /home/jenkins/.vagrant.d/gems/gems/fog-core-1.36.0/lib/fog/core/services_mixin.rb:16:in `new'
        from /home/jenkins/.vagrant.d/gems/gems/fog-core-1.36.0/lib/fog/compute.rb:65:in `new'
        from /home/jenkins/.vagrant.d/gems/gems/fog-core-1.36.0/lib/fog/core/services_mixin.rb:4:in `[]'
        from /home/jenkins/.vagrant.d/gems/gems/fog-libvirt-0.0.4/lib/fog/libvirt/models/compute/server.rb:269:in `addresses'
        from /home/jenkins/.vagrant.d/gems/gems/vagrant-libvirt-1.0.2/lib/vagrant-libvirt/action/wait_till_up.rb:39:in `block (3 levels) in call'
        from /home/jenkins/.vagrant.d/gems/gems/fog-core-1.36.0/lib/fog/core/model.rb:72:in `instance_eval'
        from /home/jenkins/.vagrant.d/gems/gems/fog-core-1.36.0/lib/fog/core/model.rb:72:in `block in wait_for'
        from /home/jenkins/.vagrant.d/gems/gems/fog-core-1.36.0/lib/fog/core/wait_for.rb:7:in `block in wait_for'
        from /home/jenkins/.vagrant.d/gems/gems/fog-core-1.36.0/lib/fog/core/wait_for.rb:6:in `loop'
        from /home/jenkins/.vagrant.d/gems/gems/fog-core-1.36.0/lib/fog/core/wait_for.rb:6:in `wait_for'
        from /home/jenkins/.vagrant.d/gems/gems/fog-core-1.36.0/lib/fog/core/model.rb:69:in `wait_for'
        from /home/jenkins/.vagrant.d/gems/gems/vagrant-libvirt-1.0.2/lib/vagrant-libvirt/action/wait_till_up.rb:38:in `block (2 levels) in call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/util/retryable.rb:17:in `retryable'
        from /home/jenkins/.vagrant.d/gems/gems/vagrant-libvirt-1.0.2/lib/vagrant-libvirt/action/wait_till_up.rb:33:in `block in call'
        from /home/jenkins/.vagrant.d/gems/gems/vagrant-libvirt-1.0.2/lib/vagrant-libvirt/util/timer.rb:9:in `time'
        from /home/jenkins/.vagrant.d/gems/gems/vagrant-libvirt-1.0.2/lib/vagrant-libvirt/action/wait_till_up.rb:31:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/warden.rb:34:in `call'
        from /home/jenkins/.vagrant.d/gems/gems/vagrant-libvirt-1.0.2/lib/vagrant-libvirt/action/start_domain.rb:188:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/warden.rb:34:in `call'
        from /home/jenkins/.vagrant.d/gems/gems/vagrant-libvirt-1.0.2/lib/vagrant-libvirt/action/set_boot_order.rb:60:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/warden.rb:34:in `call'
        from /home/jenkins/.vagrant.d/gems/gems/vagrant-libvirt-1.0.2/lib/vagrant-libvirt/action/create_network_interfaces.rb:138:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/warden.rb:34:in `call'
        from /home/jenkins/.vagrant.d/gems/gems/vagrant-libvirt-1.0.2/lib/vagrant-libvirt/action/create_networks.rb:79:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/warden.rb:34:in `call'
        from /home/jenkins/.vagrant.d/gems/gems/vagrant-libvirt-1.0.2/lib/vagrant-libvirt/action/share_folders.rb:20:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/warden.rb:34:in `call'
        from /home/jenkins/.vagrant.d/gems/gems/vagrant-libvirt-1.0.2/lib/vagrant-libvirt/action/prepare_nfs_settings.rb:18:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/warden.rb:34:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/builtin/synced_folders.rb:86:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/warden.rb:34:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/builtin/synced_folder_cleanup.rb:28:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/warden.rb:34:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/plugins/synced_folders/nfs/action_cleanup.rb:25:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/warden.rb:34:in `call'
        from /home/jenkins/.vagrant.d/gems/gems/vagrant-libvirt-1.0.2/lib/vagrant-libvirt/action/prepare_nfs_valid_ids.rb:12:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/warden.rb:34:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/builtin/provision.rb:80:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/warden.rb:34:in `call'
        from /home/jenkins/.vagrant.d/gems/gems/vagrant-berkshelf-4.1.0/lib/vagrant-berkshelf/action/upload.rb:13:in `call'
       in `call'
        from /home/jenkins/.vagrant.d/gems/gems/vagrant-berkshelf-4.1.0/lib/vagrant-berkshelf/action/install.rb:10:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/warden.rb:34:in `call'
        from /home/jenkins/.vagrant.d/gems/gems/vagrant-berkshelf-4.1.0/lib/vagrant-berkshelf/action/save.rb:10:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/warden.rb:34:in `call'
        from /home/jenkins/.vagrant.d/gems/gems/vagrant-libvirt-1.0.2/lib/vagrant-libvirt/action/create_domain.rb:201:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/warden.rb:34:in `call'
        from /home/jenkins/.vagrant.d/gems/gems/vagrant-libvirt-1.0.2/lib/vagrant-libvirt/action/create_domain_volume.rb:51:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/warden.rb:34:in `call'
        from /home/jenkins/.vagrant.d/gems/gems/vagrant-libvirt-1.0.2/lib/vagrant-libvirt/action/handle_box_image.rb:109:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/warden.rb:34:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/builtin/handle_box.rb:56:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/warden.rb:34:in `call'
        from /home/jenkins/.vagrant.d/gems/gems/vagrant-libvirt-1.0.2/lib/vagrant-libvirt/action/handle_storage_pool.rb:50:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/warden.rb:34:in `call'
        from /home/jenkins/.vagrant.d/gems/gems/vagrant-libvirt-1.0.2/lib/vagrant-libvirt/action/set_name_of_domain.rb:35:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/warden.rb:34:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/warden.rb:95:in `block in finalize_action'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/warden.rb:34:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/warden.rb:34:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/builder.rb:116:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/runner.rb:66:in `block in run'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/util/busy.rb:19:in `busy'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/runner.rb:66:in `run'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/builtin/call.rb:53:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/warden.rb:34:in `call'
        from /home/jenkins/.vagrant.d/gems/gems/vagrant-berkshelf-4.1.0/lib/vagrant-berkshelf/action/share.rb:10:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/warden.rb:34:in `call'
        from /home/jenkins/.vagrant.d/gems/gems/vagrant-berkshelf-4.1.0/lib/vagrant-berkshelf/action/load.rb:10:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/warden.rb:34:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/builtin/env_set.rb:19:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/warden.rb:34:in `call'
        from /home/jenkins/.vagrant.d/gems/gems/vagrant-berkshelf-4.1.0/lib/vagrant-berkshelf/action/check.rb:12:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/warden.rb:34:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/builtin/config_validate.rb:25:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/warden.rb:34:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/builder.rb:116:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/runner.rb:66:in `block in run'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/util/busy.rb:19:in `busy'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/runner.rb:66:in `run'
       action_raw'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/machine.rb:191:in `block in action'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/environment.rb:516:in `lock'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/machine.rb:178:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/machine.rb:178:in `action'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/batch_action.rb:82:in `block (2 levels) in run'
-----> Destroying <development-centos-6-chef-11-kitchen>...
```

it looks like the fog-core and fog-libvirt updates have made an option required now, I think this should help out (the immediately previous versions of these gems have been installed on the build servers for months).